### PR TITLE
Update SSRController.cs

### DIFF
--- a/Netch/Controllers/SSRController.cs
+++ b/Netch/Controllers/SSRController.cs
@@ -34,7 +34,7 @@ namespace Netch.Controllers
 
             Instance = MainController.GetProcess();
             Instance.StartInfo.FileName = "bin\\ShadowsocksR.exe";
-            Instance.StartInfo.Arguments = $"-s {server.Hostname} -p {server.Port} -k \"{server.Password}\" -m {server.EncryptMethod}";
+            Instance.StartInfo.Arguments = $"-s {server.Hostname} -p {server.Port} -t 600 -k \"{server.Password}\" -m {server.EncryptMethod}";
 
             if (!string.IsNullOrEmpty(server.Protocol))
             {


### PR DESCRIPTION
ssr启动参数添加tcp的socket超时参数 -t 600 以解决cod16中因使用ssr节点时tcp超时导致的与服务器连接被认为丢失问题 原为默认60秒